### PR TITLE
Add newline to end of configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -282,3 +282,4 @@ AC_ROXML_TUNE(xpath,
 AC_MSG_NOTICE()
 AC_CONFIG_FILES(Makefile libroxml.pc docs/doxy.cfg docs/man.cfg src/roxml_doxy.h)
 AC_OUTPUT
+


### PR DESCRIPTION
This was necessary to get libroxml to build on Ubuntu 16.
This problem has also appeared in another project: henryk/libopenkey#1