### PR TITLE
Fix memory leak on XML with trailing garbage sequence

### DIFF
--- a/src/roxml_core.c
+++ b/src/roxml_core.c
@@ -496,20 +496,22 @@ ROXML_INT int _func_load_close_node(roxml_parser_item_t *parser, char *chunk, vo
 	context->state = STATE_NODE_CONTENT;
 	context->previous_state = STATE_NODE_CONTENT;
 	context->candidat_txt = roxml_create_node(context->pos + 1, context->src, ROXML_TXT_NODE | context->type);
-#ifdef IGNORE_EMPTY_TEXT_NODES
-	while (chunk[cur] != '\0') {
-		if (chunk[cur] == '<') {
-			break;
-		} else if (!ROXML_WHITE(chunk[cur])) {
-			context->empty_text_node = 0;
-			break;
-		}
-		cur++;
-	}
-#endif /* IGNORE_EMPTY_TEXT_NODES */
-	while ((chunk[cur] != '<') && (chunk[cur] != '\0'))
-		cur++;
 
+	if (strstr(chunk, "<") != NULL) {
+#ifdef IGNORE_EMPTY_TEXT_NODES
+		while (chunk[cur] != '\0') {
+			if (chunk[cur] == '<') {
+				break;
+			} else if (!ROXML_WHITE(chunk[cur])) {
+				context->empty_text_node = 0;
+				break;
+			}
+			cur++;
+		}
+#endif /* IGNORE_EMPTY_TEXT_NODES */
+		while ((chunk[cur] != '<') && (chunk[cur] != '\0'))
+			cur++;
+	}
 	context->pos += cur;
 	return cur;
 }


### PR DESCRIPTION
While running the running code with valgrind:
```
#include <stdio.h>

#include <roxml.h>

int main(void) {
  char *xml_input =
      "<note><to>Tove</to><from>Jani</from><heading>Reminder</"
      "heading><body>Don't forget me this weekend!</body></note>1234";

  node_t *xml = NULL;

  printf("parsing XML input using roxml_load_buf\n");

  xml = roxml_load_buf(xml_input);
  if (xml == NULL) {
    printf("xml parse error");
    return 1;
  }

  roxml_close(xml);

  printf("closing XML node using roxml_close\n");

  return 0;
}
```
After program successfully terminates valgrind reports a memory leek:
```
$ valgrind --leak-check=full --leak-resolution=high --track-origins=yes --read-var-info=yes --child-silent-after-fork=yes ./leakcheck
==601== Memcheck, a memory error detector
==601== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==601== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==601== Command: ./leakcheck
==601== 
parsing XML input using roxml_load_buf
closing XML node using roxml_close
==601== 
==601== HEAP SUMMARY:
==601==     in use at exit: 80 bytes in 1 blocks
==601==   total heap usage: 30 allocs, 29 frees, 19,728 bytes allocated
==601== 
==601== 80 bytes in 1 blocks are definitely lost in loss record 1 of 1
==601==    at 0x483AB65: calloc (vg_replace_malloc.c:752)
==601==    by 0x484A6EA: roxml_create_node (roxml_core.c:48)
==601==    by 0x4854037: _func_load_close_node (in /usr/local/lib/libroxml.so.2)
==601==    by 0x4855023: roxml_parse_line (in /usr/local/lib/libroxml.so.2)
==601==    by 0x484B741: roxml_parse_buff (roxml_buff.c:40)
==601==    by 0x484AE61: roxml_load (roxml_core.c:233)
==601==    by 0x484B7CB: roxml_load_buf (roxml_buff.c:57)
==601==    by 0x10919B: main (in ../leakcheck)
==601== 
==601== LEAK SUMMARY:
==601==    definitely lost: 80 bytes in 1 blocks
==601==    indirectly lost: 0 bytes in 0 blocks
==601==      possibly lost: 0 bytes in 0 blocks
==601==    still reachable: 0 bytes in 0 blocks
==601==         suppressed: 0 bytes in 0 blocks
==601== 
==601== For counts of detected and suppressed errors, rerun with: -v
==601== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
The PR is a suggested fix for the problem. It is not thoroughly tested.