### PR TITLE
win32 build: fix win32 include to fake return values

### DIFF
--- a/src/roxml_parser.c
+++ b/src/roxml_parser.c
@@ -104,7 +104,7 @@ ROXML_INT void roxml_parser_free(roxml_parser_item_t *parser)
 
 ROXML_INT roxml_parser_item_t *roxml_parser_prepare(roxml_parser_item_t *parser)
 {
-	int i, j;
+	int i;
 	roxml_parser_item_t *new;
 	roxml_parser_item_t *collision;
 

--- a/src/roxml_win32_native.h
+++ b/src/roxml_win32_native.h
@@ -25,10 +25,14 @@
 typedef HANDLE pthread_t;
 typedef CRITICAL_SECTION pthread_mutex_t;
 
-#define pthread_self()                 GetCurrentThread()
-#define pthread_mutex_init(a, b)       InitializeCriticalSection(a)
-#define pthread_mutex_lock(a)          EnterCriticalSection(a)
-#define pthread_mutex_unlock(a)                LeaveCriticalSection(a)
-#define pthread_mutex_destroy(a)       DeleteCriticalSection(a)
+#define pthread_self()                 ((unsigned long int) GetCurrentThread())
+#define pthread_mutex_init(a, b)       ({int ret = 0; InitializeCriticalSection(a); ret;})
+#define pthread_mutex_lock(a)          ({int ret = 0; EnterCriticalSection(a); ret;})
+#define pthread_mutex_unlock(a)        ({int ret = 0; LeaveCriticalSection(a); ret;})
+#define pthread_mutex_destroy(a)       ({int ret = 0; DeleteCriticalSection(a); ret; })
+
+#ifndef ENODATA
+#define ENODATA 61
+#endif
 
 #endif /* ROXML_WIN32_NATIVE_THREAD_H */


### PR DESCRIPTION
Fix build win32 with mingw on Debian 9 and 10 (add missing return values, which always return 0 since the windows interface does only return void).
In addition I just fixed a unused variable error.