### PR TITLE
roxml_core.h: add missing extern

### DIFF
--- a/src/roxml_core.h
+++ b/src/roxml_core.h
@@ -15,9 +15,9 @@
 #include "roxml_internal.h"
 
 #ifdef __DEBUG
-unsigned int _nb_node;
-unsigned int _nb_attr;
-unsigned int _nb_text;
+extern unsigned int _nb_node;
+extern unsigned int _nb_attr;
+extern unsigned int _nb_text;
 #endif
 
 /** \brief internal function


### PR DESCRIPTION
The build fails on unittest building in both the cmake-based and
autoconf-based build path because the _nb_* variables are not declared
as extern in roxml_core.h.

We get the following errors:

	/bin/bash ./libtool  --tag=CC   --mode=link gcc -DUNITTEST -DREENTRANT -DLINUX -D__DEBUG -DIGNORE_EMPTY_TEXT_NODES -Wall -Wextra  -Wno-unused -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -DCONFIG_XML_CONTENT -DCONFIG_XML_NAV -DCONFIG_XML_BUFF -DCONFIG_XML_COMMIT -DCONFIG_XML_EDIT -DCONFIG_XML_FILE -DCONFIG_XML_XPATH -g -O2   -o unittest/roxml.unitC unittest/roxml_unitC-unittest.o unittest/roxml_unitC-roxml.test.o unittest/libroxml_test.a
	libtool: link: gcc -DUNITTEST -DREENTRANT -DLINUX -D__DEBUG -DIGNORE_EMPTY_TEXT_NODES -Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -DCONFIG_XML_CONTENT -DCONFIG_XML_NAV -DCONFIG_XML_BUFF -DCONFIG_XML_COMMIT -DCONFIG_XML_EDIT -DCONFIG_XML_FILE -DCONFIG_XML_XPATH -g -O2 -o unittest/roxml.unitC unittest/roxml_unitC-unittest.o unittest/roxml_unitC-roxml.test.o  unittest/libroxml_test.a
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_buff.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_buff.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_buff.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_commit.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_commit.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_commit.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_core.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_core.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_core.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_edit.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_edit.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_edit.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_file.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_file.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_file.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_xpath.o):/home/edt/tmp/libroxml/src/roxml_core.h:20: multiple definition of `_nb_text'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:20: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_xpath.o):/home/edt/tmp/libroxml/src/roxml_core.h:19: multiple definition of `_nb_attr'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:19: first defined here
	/usr/bin/ld: unittest/libroxml_test.a(unittest_libroxml_test_a-roxml_xpath.o):/home/edt/tmp/libroxml/src/roxml_core.h:18: multiple definition of `_nb_node'; unittest/roxml_unitC-roxml.test.o:/home/edt/tmp/libroxml/./src/roxml_core.h:18: first defined here
	collect2: error: ld returned 1 exit status

Partially fixes #82.

Signed-off-by: Emmanuel Deloget <logout@free.fr>