### PR TITLE
Fix roxml_strtonum() validation for values containing the letter "e"

### DIFF
--- a/src/roxml_utils.h
+++ b/src/roxml_utils.h
@@ -90,7 +90,10 @@ ROXML_STATIC_INLINE ROXML_INT int roxml_unlock(node_t *n)
 #ifdef CONFIG_XML_FLOAT
 ROXML_STATIC_INLINE ROXML_INT double roxml_strtonum(const char *str, char **end)
 {
-	return strtod(str, end);
+//	Fix the bug when the letter "e" is given in str.
+//	This letter is considered an exponential, returning mistakenly a number alike value.
+//	return strtod(str, end);
+	return strtoull(str, end);
 }
 #else /* CONFIG_XML_FLOAT */
 ROXML_STATIC_INLINE ROXML_INT double roxml_strtonum(const char *str, char **end)


### PR DESCRIPTION
The letter "e" is considered an exponential, misleading the output of the function roxml_is_number.

"A non-empty sequence of decimal digits optionally containing a radix character; the an optional exponent part consisting of the character 'e' or the character 'E', optionally followed by a '+' or '-' character, and then followed by one or more decimal digits"